### PR TITLE
persisting database directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go Constinous Delivery Server
+# Go Continuous Delivery Server
 
 The following are the containers used in the docker-compose.yml for the server
 

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -65,7 +65,7 @@ if [ ! -z "${VAULT_ADDR}" ]; then
 fi
 
 # symlink persistent data from /data 
-for dir in /opt/go-server/artifacts /opt/go-server/dba /etc/go /var/log/go-server;
+for dir in /opt/go-server/artifacts /opt/go-server/dba /opt/go-server/db /etc/go /var/log/go-server;
 do
   data_dir=/data/$(basename $dir)
   mkdir -p $data_dir


### PR DESCRIPTION
The database directory is now persisted. So we do not lose build numbers once we reboot the server.
